### PR TITLE
Bugfix for HTTP to HTTPS redirection: wrong variable was used

### DIFF
--- a/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
+++ b/files/gitlab-cookbooks/gitlab/templates/default/nginx-gitlab-http.conf.erb
@@ -46,7 +46,7 @@ server {
 <% end %>
   server_name <%= @fqdn %>;
   server_tokens off; ## Don't show the nginx version number, a security best practice
-  return 301 https://<%= @fqdn %>:<%= @port %>$request_uri;
+  return 302 https://<%= @fqdn %>:<%= @listen_port %>$request_uri;
   access_log  <%= @log_directory %>/gitlab_access.log gitlab_access;
   error_log   <%= @log_directory %>/gitlab_error.log;
 }


### PR DESCRIPTION
first:
301 is not cacheable, generates a lot of excessive requests for project icons
302 cached on client correctly

second, the most important fix:
there is an incorrect @port variable for redirect to HTTPS was used. Replcaed with listen_port and problems with icons are went away.